### PR TITLE
check object before accessing properties

### DIFF
--- a/lib/GraphicsMagick.js
+++ b/lib/GraphicsMagick.js
@@ -161,7 +161,7 @@ class GraphicsMagick {
     const tasks = []
 
     Object.keys(this._options.transforms).forEach((name) => {
-      if (!model[name].url) {
+      if (!model[name] || !model[name].url) {
         return
       }
 


### PR DESCRIPTION
Original error message:

``` javascript
/opt/node_modules/mongoose-crate-gm/lib/GraphicsMagick.js:165
      if (!model[name].url) {
                      ^

TypeError: Cannot read property 'url' of undefined
```

I don't know why the error occurred in the first place, but this pull request fixes it. Furthermore, the additional check is rather prudent, anyway.
